### PR TITLE
Lab 043

### DIFF
--- a/pages/labs/lab042.vue
+++ b/pages/labs/lab042.vue
@@ -1,44 +1,44 @@
 <script setup>
-import { MeshBuilder, PointerDragBehavior } from "babylonjs";
+  import { MeshBuilder, PointerDragBehavior } from "babylonjs";
 
-definePageMeta({
-  featured: true,
-  title: "Lab 042 - Lay out 3D objects in a line",
-  description: "Lay out 3D objects in a line"
-});
+  definePageMeta({
+    featured: false,
+    title: "Lab 042 - Lay out 3D objects in a line",
+    description: "Lay out 3D objects in a line"
+  });
 
-const createLabContent = async (scene) => {
-  const addBoxesToLayout = (numBoxes, layout, scene) => {
-    // Add the layout box
-    layout.position.y = 0.5;
+  const createLabContent = async (scene) => {
+    const addBoxesToLayout = (numBoxes, layout, scene) => {
+      // Add the layout box
+      layout.position.y = 0.5;
 
-    // Add the boxes as children of the layout with unique names and space them out evenly on the x-axis
-    for (let i = 0; i < numBoxes; i++) {
-      const box = MeshBuilder.CreateBox("box" + i, { size: 0.2 }, scene);
-      box.name = "box" + i;
-      box.position.x = (i - (numBoxes - 1) / 2) * 0.25;
-      box.position.y = 0.5;
+      // Add the boxes as children of the layout with unique names and space them out evenly on the x-axis
+      for (let i = 0; i < numBoxes; i++) {
+        const box = MeshBuilder.CreateBox("box" + i, { size: 0.2 }, scene);
+        box.name = "box" + i;
+        box.position.x = (i - (numBoxes - 1) / 2) * 0.25;
+        box.position.y = 0.5;
 
-      const grabber = new PointerDragBehavior();
-      grabber.moveAttached = false; // Disable moving the grabber itself
-      grabber.onDragObservable.add((eventData) => {
-        box.position.x += eventData.delta.x;
-        box.position.y += eventData.delta.y;
-      });
+        const grabber = new PointerDragBehavior();
+        grabber.moveAttached = false; // Disable moving the grabber itself
+        grabber.onDragObservable.add((eventData) => {
+          box.position.x += eventData.delta.x;
+          box.position.y += eventData.delta.y;
+        });
 
-      box.addBehavior(grabber);
-      box.parent = layout;
-    }
+        box.addBehavior(grabber);
+        box.parent = layout;
+      }
+    };
+
+    const layout = MeshBuilder.CreateBox("box", { size: 0.5 }, scene);
+
+    const numBoxes = 6;
+    addBoxesToLayout(numBoxes, layout, scene);
   };
 
-  const layout = MeshBuilder.CreateBox("box", { size: 0.5 }, scene);
-
-  const numBoxes = 6;
-  addBoxesToLayout(numBoxes, layout, scene);
-};
-
-const bjsCanvas = ref(null);
-useCanvatoriumScene(bjsCanvas, createLabContent);
+  const bjsCanvas = ref(null);
+  useCanvatoriumScene(bjsCanvas, createLabContent);
 </script>
 
 <template>

--- a/pages/labs/lab043.vue
+++ b/pages/labs/lab043.vue
@@ -1,5 +1,6 @@
 <script setup>
   import { MeshBuilder } from "babylonjs";
+  import { AdvancedDynamicTexture, Button, TextBlock } from "babylonjs-gui";
 
   definePageMeta({
     featured: false,
@@ -8,7 +9,35 @@
   });
 
   const createLabContent = async (scene) => {
-    MeshBuilder.CreateBox("box", { size: 1 }, scene).position.y = 0.5;
+    const sparticus = generateCard(scene);
+    sparticus.position.x = Math.random() * 10 - 5;
+    sparticus.position.z = Math.random() * 10 - 5;
+    sparticus.position.y = Math.random() + 1.5;
+
+    for (let i = 0; i < 99; i++) {
+      const card = generateCard(scene);
+      card.position.x = Math.random() * 10 - 5;
+      card.position.z = Math.random() * 10 - 5;
+      card.position.y = Math.random() + 1.5;
+    }
+  };
+
+  const generateCard = (scene) => {
+    const plane = MeshBuilder.CreatePlane("plane", { width: 0.5, height: 0.5 }, scene);
+
+    const advancedTexture = AdvancedDynamicTexture.CreateForMesh(plane);
+    advancedTexture.name = "card-texture";
+    advancedTexture.background = labColors.slate8;
+
+    const titleText = new TextBlock("title-text");
+
+    titleText.text = "I'm Sparticus!";
+    titleText.color = "white";
+    titleText.fontSize = 96;
+
+    advancedTexture.addControl(titleText);
+
+    return plane;
   };
 
   const bjsCanvas = ref(null);

--- a/pages/labs/lab043.vue
+++ b/pages/labs/lab043.vue
@@ -1,20 +1,16 @@
 <script setup>
   import { MeshBuilder } from "babylonjs";
-  import { AdvancedDynamicTexture, Button, TextBlock } from "babylonjs-gui";
+  import { AdvancedDynamicTexture, TextBlock } from "babylonjs-gui";
 
   definePageMeta({
-    featured: false,
+    featured: true,
     title: "Lab 043",
-    description: "Lots of UI, too much UI?"
+    description: "Lots of UI, too much UI?",
+    labNotes: `How many AdvancedDynamicTextures can I load in a WebXR scene on an Meta Quest 2? It seems like 30 to 50 is a safe bet for now. These cards only have a single text block and a SixDofDragBehavior. When I make more advanced cards with more controls, I may have to reduce the number of cards in a scene.`
   });
 
   const createLabContent = async (scene) => {
-    const sparticus = generateCard(scene);
-    sparticus.position.x = Math.random() * 10 - 5;
-    sparticus.position.z = Math.random() * 10 - 5;
-    sparticus.position.y = Math.random() + 1.5;
-
-    for (let i = 0; i < 49; i++) {
+    for (let i = 0; i < 50; i++) {
       const card = generateCard(scene);
       card.position.x = Math.random() * 10 - 5;
       card.position.z = Math.random() * 10 - 5;
@@ -37,7 +33,6 @@
 
     advancedTexture.addControl(titleText);
 
-    // Make the plane grabbable
     const sixDofDragBehavior = new BABYLON.SixDofDragBehavior();
     sixDofDragBehavior.allowMultiPointers = true;
     plane.addBehavior(sixDofDragBehavior);

--- a/pages/labs/lab043.vue
+++ b/pages/labs/lab043.vue
@@ -1,0 +1,20 @@
+<script setup>
+  import { MeshBuilder } from "babylonjs";
+
+  definePageMeta({
+    featured: false,
+    title: "Lab 043",
+    description: "Lots of UI, too much UI?"
+  });
+
+  const createLabContent = async (scene) => {
+    MeshBuilder.CreateBox("box", { size: 1 }, scene).position.y = 0.5;
+  };
+
+  const bjsCanvas = ref(null);
+  useCanvatoriumScene(bjsCanvas, createLabContent);
+</script>
+
+<template>
+  <canvas id="bjsCanvas" ref="bjsCanvas"></canvas>
+</template>

--- a/pages/labs/lab043.vue
+++ b/pages/labs/lab043.vue
@@ -14,16 +14,16 @@
     sparticus.position.z = Math.random() * 10 - 5;
     sparticus.position.y = Math.random() + 1.5;
 
-    for (let i = 0; i < 99; i++) {
+    for (let i = 0; i < 49; i++) {
       const card = generateCard(scene);
       card.position.x = Math.random() * 10 - 5;
       card.position.z = Math.random() * 10 - 5;
-      card.position.y = Math.random() + 1.5;
+      card.position.y = Math.random() + 0.5;
     }
   };
 
   const generateCard = (scene) => {
-    const plane = MeshBuilder.CreatePlane("plane", { width: 0.5, height: 0.5 }, scene);
+    const plane = MeshBuilder.CreatePlane("plane", { width: 0.3, height: 0.3 }, scene);
 
     const advancedTexture = AdvancedDynamicTexture.CreateForMesh(plane);
     advancedTexture.name = "card-texture";
@@ -36,6 +36,11 @@
     titleText.fontSize = 96;
 
     advancedTexture.addControl(titleText);
+
+    // Make the plane grabbable
+    const sixDofDragBehavior = new BABYLON.SixDofDragBehavior();
+    sixDofDragBehavior.allowMultiPointers = true;
+    plane.addBehavior(sixDofDragBehavior);
 
     return plane;
   };


### PR DESCRIPTION
How many AdvancedDynamicTextures can I load in a WebXR scene on an Meta Quest 2? It seems like 30 to 50 is a safe bet for now. These cards only have a single text block and a SixDofDragBehavior. When I make more advanced cards with more controls, I may have to reduce the number of cards in a scene.